### PR TITLE
Nuke Number variable section in index.html

### DIFF
--- a/funkyguide/index.html
+++ b/funkyguide/index.html
@@ -551,7 +551,7 @@
                       			</tr>
                       			<tr>
                       				<td>LandingGear</td>
-                      				<td>Archaic FT input type. Use <code>GearDown</code> instead when making FT inputs.</td>
+                      				<td>Archaic FT input type. Use <code>GearDown</code> instead when making FT inputs. Note that this value to 0 when the gears are deployed.</td>
                       				<td>(0, 1)</td>
                       			</tr>
                             <tr>

--- a/funkyguide/index.html
+++ b/funkyguide/index.html
@@ -409,6 +409,15 @@
                       			<b>TL;DR: simply numbers, but everything is unique (requiring special attention from you).</b>
                       			The following is a list of all number type variables and their possible values.
                       		</p>
+                        <p>
+                          Many variables (e.g. Pitch, Roll, Yaw) will be set to their maximum values if a keyboard is used as input. Values in between are obtainable if a controller/joystick is used (including ones on screen).
+                          </p>
+                        <p>
+                          Tiles (~) are used if the variable allows decimals (analog).
+                        </p>
+                        <p>
+                          Unless noted otherwise, values are inclusive.
+                          </p>
                       		<table class="table" style="width:100%">
                       			<tr>
                       				<th>Variable</th>
@@ -418,17 +427,17 @@
                       			<tr>
                       				<td>Pitch</td>
                       				<td>The amount of Pitch input as a proportion</td>
-                      				<td>(-1, 0, 1) / alternatively (-1~1) if joystick</td>
+                      				<td>(-1~1)</td>
                       			</tr>
                       			<tr>
                       				<td>Roll</td>
                       				<td>The amount of Roll input as a proportion</td>
-                      				<td>(-1, 0, 1) / alternatively (-1~1) if joystick</td>
+                      				<td>(-1~1)</td>
                       			</tr>
                       			<tr>
                       				<td>Yaw</td>
                       				<td>The amount of Yaw input as a proportion</td>
-                      				<td>(-1, 0, 1) / alternatively (-1~1) if joystick</td>
+                      				<td>(-1~1)</td>
                       			</tr>
                       			<tr>
                       				<td>Trim</td>
@@ -547,8 +556,8 @@
                       			</tr>
                             <tr>
                       				<td>Brake</td>
-                      				<td>Whether or not Brake is pressed</td>
-                      				<td><code>0</code> / <code>1</code></td>
+                      				<td>Whether or not Brake is pressed. Analogue if using controller/joystick.</td>
+                      				<td>(0~1)</td>
                       			</tr>
                             <tr>
                       				<td>TargetHeading</td>
@@ -589,7 +598,7 @@
                       			</tr>
                       			<tr>
                       				<td>GearDown</td>
-                      				<td>Whether or not landing gear is on or off</td>
+                      				<td>Whether or not landing gear is deployed or not</td>
                       				<td><code>true</code> / <code>false</code></td>
                       			</tr>
                       			<tr>


### PR DESCRIPTION
Changed brakes from `0`/ `1` to (0,1) as well as mentioning the use of tiles (~) and the difference in keyboard and joystick controls.